### PR TITLE
Add `cl` and `prepare_sql_execute` request types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.theprez</groupId>
     <artifactId>codeforibmiserver</artifactId>
-    <version>1.0.0-alpha-5</version>
+    <version>1.0.0-alpha-6</version>
     <name>CodeForIBMiServer</name>
     <description>Server-side support for "Code for IBM i" VSCode extension</description>
     <url>https://github.com/ThePrez/CodeForIBMiServer</url>

--- a/src/main/java/com/github/theprez/codefori/DataStreamProcessor.java
+++ b/src/main/java/com/github/theprez/codefori/DataStreamProcessor.java
@@ -18,6 +18,7 @@ import com.github.theprez.codefori.requests.Ping;
 import com.github.theprez.codefori.requests.PrepareSql;
 import com.github.theprez.codefori.requests.PreparedExecute;
 import com.github.theprez.codefori.requests.Reconnect;
+import com.github.theprez.codefori.requests.RunCL;
 import com.github.theprez.codefori.requests.RunSql;
 import com.github.theprez.codefori.requests.RunSqlMore;
 import com.github.theprez.codefori.requests.UnknownReq;
@@ -110,6 +111,9 @@ public class DataStreamProcessor implements Runnable {
                     case "execute":
                         final PrepareSql prevP = m_prepStmtMap.get(reqObj.get("cont_id").getAsString());
                         dispatch(new PreparedExecute(this, reqObj, prevP));
+                        break;
+                    case "cl":
+                        dispatch(new RunCL(this, m_conn, reqObj));
                         break;
                     case "connect":
                         dispatch(new Reconnect(this, m_conn, reqObj));

--- a/src/main/java/com/github/theprez/codefori/requests/PrepareSql.java
+++ b/src/main/java/com/github/theprez/codefori/requests/PrepareSql.java
@@ -17,9 +17,11 @@ import com.ibm.as400.access.AS400JDBCPreparedStatement;
 public class PrepareSql extends BlockRetrievableRequest {
 
     private AS400JDBCPreparedStatement m_stmt = null;
+    private final PreparedExecute m_executeTask;
 
-    public PrepareSql(final DataStreamProcessor _io, final SystemConnection m_conn, final JsonObject _reqObj) {
+    public PrepareSql(final DataStreamProcessor _io, final SystemConnection m_conn, final JsonObject _reqObj, final boolean _isImmediateExecute) {
         super(_io, m_conn, _reqObj);
+        m_executeTask = _isImmediateExecute? new PreparedExecute(_io, _reqObj, this) : null;
     }
 
     @Override
@@ -62,6 +64,9 @@ public class PrepareSql extends BlockRetrievableRequest {
         }
 
         addReplyData("metadata", metaData);
+        if(null != m_executeTask) {
+            m_executeTask.go();
+        }
     }
 
     private String getModeString(int _parameterMode) {

--- a/src/main/java/com/github/theprez/codefori/requests/RunCL.java
+++ b/src/main/java/com/github/theprez/codefori/requests/RunCL.java
@@ -27,6 +27,11 @@ public class RunCL extends BlockRetrievableRequest {
     }
 
     @Override
+    public boolean isForcedSynchronous() {
+        return true;
+    }
+
+    @Override
     public void go() throws Exception {
         final String cmd = getRequestField("cmd").getAsString();
         final AS400JDBCConnection jdbcConn = getSystemConnection().getJdbcConnection();
@@ -43,13 +48,12 @@ public class RunCL extends BlockRetrievableRequest {
         clStmt.close();
 
         Statement resultsStmt = jdbcConn.createStatement();
-        m_rs = resultsStmt.executeQuery  ("SELECT *  FROM TABLE(QSYS2.JOBLOG_INFO('*')) A limit 99999 offset "+pos);
+        m_rs = resultsStmt.executeQuery("SELECT *  FROM TABLE(QSYS2.JOBLOG_INFO('*')) A limit 99999 offset " + pos);
         addReplyData("joblog", super.getNextDataBlock(Integer.MAX_VALUE));
-        
+
     }
 
     AS400JDBCPreparedStatement getStatement() {
         return m_stmt;
     }
-
 }

--- a/src/main/java/com/github/theprez/codefori/requests/RunCL.java
+++ b/src/main/java/com/github/theprez/codefori/requests/RunCL.java
@@ -1,0 +1,55 @@
+package com.github.theprez.codefori.requests;
+
+import java.sql.CallableStatement;
+import java.sql.ParameterMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import com.github.theprez.codefori.ClientRequest;
+import com.github.theprez.codefori.DataStreamProcessor;
+import com.github.theprez.codefori.SystemConnection;
+import com.google.gson.JsonObject;
+import com.ibm.as400.access.AS400JDBCConnection;
+import com.ibm.as400.access.AS400JDBCPreparedStatement;
+
+public class RunCL extends BlockRetrievableRequest {
+
+    private AS400JDBCPreparedStatement m_stmt = null;
+
+    public RunCL(final DataStreamProcessor _io, final SystemConnection m_conn, final JsonObject _reqObj) {
+        super(_io, m_conn, _reqObj);
+    }
+
+    @Override
+    public void go() throws Exception {
+        final String cmd = getRequestField("cmd").getAsString();
+        final AS400JDBCConnection jdbcConn = getSystemConnection().getJdbcConnection();
+        Statement jobLogPosStmt = jdbcConn.createStatement();
+        ResultSet posRs = jobLogPosStmt.executeQuery("SELECT COUNT(*)  FROM TABLE(QSYS2.JOBLOG_INFO('*')) A");
+        posRs.next();
+        int pos = posRs.getInt(1);
+        posRs.close();
+        jobLogPosStmt.close();
+
+        CallableStatement clStmt = jdbcConn.prepareCall("CALL QSYS2.QCMDEXC(?)");
+        clStmt.setString(1, cmd);
+        clStmt.execute();
+        clStmt.close();
+
+        Statement resultsStmt = jdbcConn.createStatement();
+        m_rs = resultsStmt.executeQuery  ("SELECT *  FROM TABLE(QSYS2.JOBLOG_INFO('*')) A limit 99999 offset "+pos);
+        addReplyData("joblog", super.getNextDataBlock(Integer.MAX_VALUE));
+        
+    }
+
+    AS400JDBCPreparedStatement getStatement() {
+        return m_stmt;
+    }
+
+}


### PR DESCRIPTION

`prepare_sql_execute` creates a prepared statement, binds parameters, and executes, all in one step
`cl` calls CL and returns the job log info 

Examples
```json
{id: "41","type":"prepare_sql_execute","sql": "INSERT INTO JESSEG.SIMPLE VALUES(?,?)","parameters":[111, "Holy hell"]}
{id:"cltest1","type":"cl", "cmd":"cPYF FROMFILE(JESSEG/SIMPLE) TOFILE(JESSEG/SIMPLE2) MBROPT(*REPLACE) CRTFILE(*YES)"}
```